### PR TITLE
Kill Toolserver database dependency.

### DIFF
--- a/reports/general/blankanontalks.py
+++ b/reports/general/blankanontalks.py
@@ -35,20 +35,17 @@ data as of <onlyinclude>%s</onlyinclude>.'''
         cursor.execute('''
 /* blankanontalks.py SLOW_OK */
 SELECT
-  CONVERT(ns_name USING utf8) AS ns_name,
+  page_namespace,
   page_title
 FROM page
-JOIN toolserver.namespace
-ON ns_id = page_namespace
-WHERE dbname = ?
 AND page_namespace = 3
 AND page_title RLIKE ?
 AND page_len = 0
 LIMIT 1000;
-''' , (self.site + '_p', r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'))
+''' , (r'^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'))
 
-        for ns_name, page_title in cursor:
-            full_page_title = u'[[%s:%s|%s]]' % (ns_name, page_title, page_title)
+        for page_namespace, page_title in cursor:
+            full_page_title = u'[[{{subst:ns:%s}}:%s|%s]]' % (page_namespace, page_title, page_title)
             yield (full_page_title, )
 
         cursor.close()


### PR DESCRIPTION
Untested. This is an alternative to mzmcbride/database-reports/pull/18.