### PR TITLE
Exclude dated file categories

### DIFF
--- a/reports/enwiki/emptycats.py
+++ b/reports/enwiki/emptycats.py
@@ -25,9 +25,9 @@ class report(reports.report):
 
     def get_preamble_template(self):
         return u'''Empty categories not in [[:Category:Wikipedia soft redirected categories]], not in \
-[[:Category:Disambiguation categories]], not in [[:Category:Monthly clean-up category counter]], \
-and do not contain "(-importance|\-class|assess|articles missing|articles in need of|articles undergoing|\
-articles to be|articles not yet|articles with|articles without|articles needing|\
+[[:Category:Disambiguation categories]], not in [[:Category:Monthly clean-up category counter]], not tagged \
+with {{tl|SpeedyMaintanceCat}}, and not containing "(-importance|\-class|assess|articles missing|articles in need of|\
+articles undergoing|articles to be|articles not yet|articles with|articles without|articles needing|\
 Wikipedia featured topics)"; data as of <onlyinclude>%s</onlyinclude>.'''
 
     def get_table_columns(self):
@@ -61,7 +61,8 @@ Wikipedia featured topics)"; data as of <onlyinclude>%s</onlyinclude>.'''
                         AND tl_namespace = 10
                         AND (tl_title = 'Empty_category' OR
                              tl_title = 'Possibly_empty_category' OR
-                             tl_title = 'Monthly_clean-up_category'));
+                             tl_title = 'Monthly_clean-up_category' OR
+                             tl_title = 'SpeedyMaintanceCat'));
         ''')
 
         for page_title, page_len in cursor:

--- a/reports/enwiki/emptycats.py
+++ b/reports/enwiki/emptycats.py
@@ -26,7 +26,7 @@ class report(reports.report):
     def get_preamble_template(self):
         return u'''Empty categories not in [[:Category:Wikipedia soft redirected categories]], not in \
 [[:Category:Disambiguation categories]], not in [[:Category:Monthly clean-up category counter]], not tagged \
-with {{tl|SpeedyMaintanceCat}}, and not containing "(-importance|\-class|assess|articles missing|articles in need of|\
+with {{tl|Maintenance category autotag}}, and not containing "(-importance|\-class|assess|articles missing|articles in need of|\
 articles undergoing|articles to be|articles not yet|articles with|articles without|articles needing|\
 Wikipedia featured topics)"; data as of <onlyinclude>%s</onlyinclude>.'''
 

--- a/reports/enwiki/emptycats.py
+++ b/reports/enwiki/emptycats.py
@@ -62,7 +62,7 @@ Wikipedia featured topics)"; data as of <onlyinclude>%s</onlyinclude>.'''
                         AND (tl_title = 'Empty_category' OR
                              tl_title = 'Possibly_empty_category' OR
                              tl_title = 'Monthly_clean-up_category' OR
-                             tl_title = 'SpeedyMaintanceCat'));
+                             tl_title = 'Maintenance_category_autotag'));
         ''')
 
         for page_title, page_len in cursor:


### PR DESCRIPTION
Each of the `Disputed non-free Wikipedia files as of`, `Replaceable non-free use to be decided after`, `Wikipedia files with the same name on Wikimedia Commons as of`, `Wikipedia files with unknown copyright status as of`, and `Wikipedia files with unknown source as of` categories, which are created daily, are tagged with {{SpeedyMaintanceCat}}, which can be used to filter them out, since they are not expected to be populated every day, and are deleted regularly without needing to be tagged with C1.