### PR TITLE
Replace chrono with time 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "dirs",
  "env_logger",
  "log",
@@ -246,6 +245,7 @@ dependencies = [
  "mysql_async",
  "regex",
  "serde",
+ "time 0.3.5",
  "tokio",
  "toml",
  "toolforge",
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libz-sys"
@@ -1545,9 +1545,19 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "libc",
+ "time-macros 0.2.3",
 ]
 
 [[package]]
@@ -1559,6 +1569,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "time-macros-impl"

--- a/dbreps2/Cargo.toml
+++ b/dbreps2/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.50"
-chrono = "0.4"
 dirs = "4.0"
 env_logger = "0.8"
 log = "0.4"
@@ -16,6 +15,7 @@ mwapi = "0.2.2"
 mysql_async = "0.27"
 regex = "1.0"
 serde = {version = "1.0", features = ["derive"]}
+time = {version = "0.3", features = ["macros", "parsing"]}
 tokio = {version = "1.0", features = ["full"]}
 toml = "0.5.8"
 toolforge = {version = "0.3", features = ["mysql"]}

--- a/dbreps2/src/enwiki/potenshblps2.rs
+++ b/dbreps2/src/enwiki/potenshblps2.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use dbreps2::{str_vec, Frequency, Report};
 use mysql_async::prelude::*;
 use mysql_async::Conn;
+use time::OffsetDateTime;
 
 pub struct Row {
     page_title: String,
@@ -78,10 +79,7 @@ ORDER BY
     }
 
     async fn run_query(&self, conn: &mut Conn) -> Result<Vec<Row>> {
-        let current_year = {
-            use chrono::prelude::*;
-            Utc::now().year()
-        };
+        let current_year = OffsetDateTime::now_utc().year();
         let mut rows = vec![];
         for year in 1900..=current_year {
             let year_rows = conn

--- a/dbreps2/src/enwiki/unbelievablelifespans.rs
+++ b/dbreps2/src/enwiki/unbelievablelifespans.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use dbreps2::{str_vec, Frequency, Linker, Report};
 use mysql_async::prelude::*;
 use mysql_async::Conn;
+use time::OffsetDateTime;
 
 pub struct Row {
     page_namespace: u32,
@@ -71,10 +72,7 @@ WHERE
     }
 
     async fn run_query(&self, conn: &mut Conn) -> Result<Vec<Row>> {
-        let current_year = {
-            use chrono::prelude::*;
-            Utc::now().year()
-        };
+        let current_year = OffsetDateTime::now_utc().year();
         let mut rows = vec![];
         for birth_year in 1..=current_year {
             let year_rows = conn


### PR DESCRIPTION
chrono isn't maintained and has active security issues. time 0.3 has
all the requisite functionality and is better supported.