### PR TITLE
Fix query in `dbreps2/src/general/dupefilenames.rs`.

### DIFF
--- a/dbreps2/src/general/dupefilenames.rs
+++ b/dbreps2/src/general/dupefilenames.rs
@@ -35,8 +35,8 @@ impl Report<Row> for DupeFileNames {
         "
         /* dupefilenames.py SLOW_OK */
         SELECT
-          LOWER(page_title),
-          GROUP_CONCAT(page_title SEPARATOR '|'),
+          LOWER(CONVERT(page_title USING utf8mb4)),
+          GROUP_CONCAT(CONVERT(page_title USING utf8mb4) SEPARATOR '|'),
           COUNT(*)
         FROM page
         WHERE page_namespace = 6


### PR DESCRIPTION
This commit is a follow-up to ed1a19c8decaaeffad5830a46f08d72a7e1a4e02.