### PR TITLE
Allow reports to be scheduled for a specific hour

### DIFF
--- a/dbreps2/src/enwiki/emptycats.rs
+++ b/dbreps2/src/enwiki/emptycats.rs
@@ -35,7 +35,7 @@ impl Report<Row> for EmptyCats {
     }
 
     fn frequency(&self) -> Frequency {
-        Frequency::Daily
+        Frequency::DailyAt(1)
     }
 
     fn query(&self) -> &'static str {


### PR DESCRIPTION
If it is that hour, we run the report. And retain the existing logic to run it if we think it's fallen behind.

Do it for the "Empty categories" report, as requested by Liz.

Also include the frequency of updates in the report description, as suggested by MZ.