### PR TITLE
Add new "Featured articles by size" report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1248,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1269,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "mwapi"
-version = "0.4.3"
+version = "0.5.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3f8e549be07678d9b9a0b5d5708ec8cc626f0dca314e8dfc0c3a8c657079b1"
+checksum = "2cbad67125f92377d6ebcd39215783a8ce3e69317d81c832757903134098fbf3"
 dependencies = [
  "js-sys",
  "mwapi_errors",
@@ -1287,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "mwapi_errors"
-version = "0.2.2"
+version = "0.3.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb58137e2ef000cdec38604cc738c925b1b6506fde54f3356d1cc9ad1e2d1eb"
+checksum = "8e0ed2f5fb2e89d62ca22a50c1d1af5fa6bc0c9507dc554fb1585165e51cec50"
 dependencies = [
  "mwtitle",
  "reqwest",
@@ -1325,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "mwbot"
-version = "0.4.3"
+version = "0.5.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2da1ef264afd6a31a6c5bf761a73d0d682583571121c0f71f74fa54fceaad3"
+checksum = "f27819948a3b33aea86180b2003b6f5a4cdd538869fad9ae921b65ab85e60914"
 dependencies = [
  "dirs",
  "libc",
@@ -1343,6 +1362,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1469,6 +1489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,6 +1606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "parsoid"
-version = "0.7.4"
+version = "0.8.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd3e90bb1712d3f2e7fa9729674a700956d9ee73b4b0bb0a6f31d651f03bfb7"
+checksum = "8dcc9c598566a50201b6f171dacf8c441e60d3af8a7c803ec67e852e8ccc7d4b"
 dependencies = [
  "indexmap",
  "kuchiki",
@@ -1985,6 +2021,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2076,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2325,6 +2371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2575,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2748,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2707,6 +2802,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2763,6 +2867,12 @@ name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "tokio",
  "toml",
  "toolforge",
+ "wikipedia_prosesize",
 ]
 
 [[package]]
@@ -3001,6 +3002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wikipedia_prosesize"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e585986491c0ec1d6d29f94ce1f84e22ef67e2748b2adb60ab9d3e33e3798b9d"
+dependencies = [
+ "parsoid",
 ]
 
 [[package]]

--- a/dbreps2/Cargo.toml
+++ b/dbreps2/Cargo.toml
@@ -21,3 +21,4 @@ time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1.24", features = ["full"] }
 toml = "0.5.8"
 toolforge = { version = "5.0", features = ["mysql"] }
+wikipedia_prosesize = "0.1.0-alpha.1"

--- a/dbreps2/Cargo.toml
+++ b/dbreps2/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "3.0.14", features = ["derive"] }
 dirs = "4.0"
 env_logger = "0.8"
 log = "0.4"
-mwbot = "0.4.3"
+mwbot = "0.5.0-alpha.3"
 mysql_async = "0.31.2"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/dbreps2/src/enwiki.rs
+++ b/dbreps2/src/enwiki.rs
@@ -18,6 +18,7 @@ mod brokenwikiprojtemps;
 mod conflictedfiles;
 mod editcount;
 mod emptycats;
+mod featuredbysize;
 mod linkedmiscapitalizations;
 mod linkedmisspellings;
 mod longstubs;
@@ -52,7 +53,7 @@ mod webhostpages;
 
 pub use {
     brokenwikiprojtemps::BrokenWikiProjTemps, conflictedfiles::ConflictedFiles,
-    editcount::EditCount, emptycats::EmptyCats,
+    editcount::EditCount, emptycats::EmptyCats, featuredbysize::FeaturedBySize,
     linkedmiscapitalizations::LinkedMiscapitalizations,
     linkedmisspellings::LinkedMisspellings, longstubs::LongStubs,
     lotnonfree::LotNonFree, newprojects::NewProjects,

--- a/dbreps2/src/enwiki/featuredbysize.rs
+++ b/dbreps2/src/enwiki/featuredbysize.rs
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 Kunal Mehta <legoktm@debian.org>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use anyhow::Result;
+use dbreps2::{str_vec, Frequency, Report};
+use mwbot::Bot;
+use mysql_async::prelude::*;
+use mysql_async::Conn;
+use wikipedia_prosesize::prosesize;
+
+pub struct Row {
+    title: String,
+    prose_size: u64,
+    word_count: u64,
+}
+
+pub struct FeaturedBySize {
+    pub(crate) bot: Bot,
+}
+
+#[async_trait::async_trait]
+impl Report<Row> for FeaturedBySize {
+    fn title(&self) -> &'static str {
+        "Featured articles by size"
+    }
+
+    fn frequency(&self) -> Frequency {
+        Frequency::Weekly
+    }
+
+    fn static_row_numbers(&self) -> bool {
+        true
+    }
+
+    fn query(&self) -> &'static str {
+        r#"
+/* featuredbysize.rs SLOW_OK */
+SELECT
+  page_title
+FROM
+  page
+  JOIN categorylinks ON cl_from = page_id
+WHERE
+  cl_to = "Featured_articles"
+  AND page_namespace = 0
+"#
+    }
+
+    async fn run_query(&self, conn: &mut Conn) -> Result<Vec<Row>> {
+        let pages: Vec<String> = conn.query(self.query()).await?;
+        let mut rows = vec![];
+        let mut handles = vec![];
+        for title in pages {
+            let page = self.bot.page(&title)?;
+            handles.push(tokio::spawn(async move {
+                let html = page.html().await?;
+                let size = prosesize(html);
+                Result::<_, anyhow::Error>::Ok((title, size))
+            }));
+        }
+        for handle in handles {
+            let (title, size) = handle.await??;
+            println!("{title}");
+            rows.push(Row {
+                title,
+                prose_size: size.prose_size(),
+                word_count: size.word_count(),
+            })
+        }
+        rows.sort_by_key(|row| row.prose_size);
+        rows.reverse();
+        Ok(rows)
+    }
+
+    fn intro(&self) -> &'static str {
+        "Articles in [[:Category:Featured articles]] sorted by prose size"
+    }
+
+    fn headings(&self) -> Vec<&'static str> {
+        vec!["Page", "Prose size", "Word count"]
+    }
+
+    fn format_row(&self, row: &Row) -> Vec<String> {
+        str_vec![
+            format!("[[{}]]", row.title.replace('_', " ")),
+            row.prose_size,
+            row.word_count
+        ]
+    }
+
+    fn code(&self) -> &'static str {
+        include_str!("featuredbysize.rs")
+    }
+}

--- a/dbreps2/src/lib.rs
+++ b/dbreps2/src/lib.rs
@@ -378,7 +378,7 @@ pub trait Report<T: Send + Sync> {
 }
 
 pub struct Runner {
-    bot: Bot,
+    pub bot: Bot,
     pub pool: Pool,
     /// Requested report with --report
     report: Option<String>,

--- a/dbreps2/src/main.rs
+++ b/dbreps2/src/main.rs
@@ -70,6 +70,12 @@ async fn main() -> Result<()> {
         .await;
     (enwiki::EditCount {}).really_run(&enwiki_runner).await;
     (enwiki::EmptyCats {}).really_run(&enwiki_runner).await;
+    (enwiki::FeaturedBySize {
+        // FIXME: figure out a less terrible way to do this
+        bot: enwiki_runner.bot.clone(),
+    })
+    .really_run(&enwiki_runner)
+    .await;
     (enwiki::LinkedMiscapitalizations {})
         .really_run(&enwiki_runner)
         .await;


### PR DESCRIPTION
Per request: <https://en.wikipedia.org/wiki/Wikipedia_talk:Database_reports#c-HJ_Mitchell-20230211183300-New_report_request:_FAs_by_length>.
    
Uses some hacks to access the `Bot` to grab page text, and then uses the
new `wikipedia_prosesize` crate to calculate prose size.