### PR TITLE
Remove "Attached KML" exemption

### DIFF
--- a/dbreps2/src/enwiki/unusedtemplatesfiltered.rs
+++ b/dbreps2/src/enwiki/unusedtemplatesfiltered.rs
@@ -26,10 +26,9 @@ use std::collections::HashSet;
 const SKIP_SUFFIXES: [&str; 4] =
     ["/testcases", "/sandbox", "/rater-data.js", "-stub"];
 
-const SKIP_PREFIXES: [&str; 14] = [
+const SKIP_PREFIXES: [&str; 13] = [
     "Adminstats/",
     "AfC_",
-    "Attached_KML/",
     "Cite_doi/",
     "Cite_pmid/",
     "Did_you_know_nominations/",


### PR DESCRIPTION
Per <https://en.wikipedia.org/wiki/Wikipedia_talk:Database_reports#c-Gonnym-20230731181200-Wikipedia:Database_reports/Unused_templates_(filtered)/Configuration_2>.