### PR TITLE
CI: run on-push CI only on main branch

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 name: Rust CI
 


### PR DESCRIPTION
this prevents running CI twice for pull requests