### PR TITLE
update pagelinks queries to use linktarget

### DIFF
--- a/dbreps2/src/enwiki/boteditcount.rs
+++ b/dbreps2/src/enwiki/boteditcount.rs
@@ -40,11 +40,12 @@ SELECT
 FROM page
 JOIN pagelinks
 ON pl_from = page_id
+JOIN linktarget on pl_target_id = lt_id
 JOIN user
-ON user_name = REPLACE(pl_title, "_", " ")
+ON user_name = REPLACE(lt_title, "_", " ")
 WHERE page_title = ?
 AND page_namespace = 4
-AND pl_namespace IN (2,3);
+AND lt_namespace IN (2,3);
 "#,
             (page,),
             |(user_name, user_editcount)| (user_name, user_editcount),

--- a/dbreps2/src/enwiki/editcount.rs
+++ b/dbreps2/src/enwiki/editcount.rs
@@ -32,16 +32,17 @@ async fn get_user_list(conn: &mut Conn, page: &str) -> Result<HashSet<String>> {
             r#"
 /* editcount.rs SLOW_OK */
 SELECT DISTINCT
- pl_title
+ lt_title
 FROM page
 JOIN pagelinks
 ON pl_from = page_id
+JOIN linktarget on pl_target_id = lt_id
 WHERE page_title = ?
 AND page_namespace = 4
-AND pl_namespace IN (2,3);
+AND lt_namespace IN (2,3);
 "#,
             (page,),
-            |(pl_title,)| pl_title,
+            |(lt_title,)| lt_title,
         )
         .await?;
     Ok(rows

--- a/dbreps2/src/enwiki/linkedmiscapitalizations.rs
+++ b/dbreps2/src/enwiki/linkedmiscapitalizations.rs
@@ -47,8 +47,9 @@ SELECT
 FROM
   page AS p1
   JOIN categorylinks ON p1.page_id = cl_from
-  JOIN pagelinks ON p1.page_title = pl_title
-  AND pl_namespace = 0
+  JOIN linktarget on p1.page_title = lt_title
+  AND lt_namespace = 0
+  JOIN pagelinks ON pl_target_id = lt_id
   JOIN page AS p2 ON pl_from = p2.page_id
   AND p2.page_namespace = 0
 WHERE

--- a/dbreps2/src/enwiki/linkedmisspellings.rs
+++ b/dbreps2/src/enwiki/linkedmisspellings.rs
@@ -47,8 +47,9 @@ SELECT
 FROM
   page AS p1
   JOIN categorylinks ON p1.page_id = cl_from
-  JOIN pagelinks ON p1.page_title = pl_title
-  AND pl_namespace = 0
+  JOIN linktarget on p1.page_title = lt_title
+  AND lt_namespace = 0
+  JOIN pagelinks ON pl_target_id = lt_id
   JOIN page AS p2 ON pl_from = p2.page_id
   AND p2.page_namespace = 0
 WHERE

--- a/dbreps2/src/enwiki/templatedisambigs.rs
+++ b/dbreps2/src/enwiki/templatedisambigs.rs
@@ -44,7 +44,7 @@ impl Report<Row> for TemplateDisambigs {
 /* templatedisambigs.rs SLOW_OK */
 SELECT
   pltmp.page_title AS template_title,
-  pltmp.pl_title AS disambiguation_title,
+  pltmp.lt_title AS disambiguation_title,
   (
     SELECT
       COUNT(*)
@@ -60,21 +60,22 @@ FROM
     SELECT
       page_namespace,
       page_title,
-      pl_namespace,
-      pl_title
+      lt_namespace,
+      lt_title
     FROM
       page
       JOIN pagelinks ON pl_from = page_id
+      JOIN linktarget ON pl_target_id = lt_id
     WHERE
       page_namespace = 10
-      AND pl_namespace = 0
+      AND lt_namespace = 0
     LIMIT
       1000000
   ) AS pltmp
   JOIN page AS pg2
   /* removes red links */
-  ON pltmp.pl_namespace = pg2.page_namespace
-  AND pltmp.pl_title = pg2.page_title
+  ON pltmp.lt_namespace = pg2.page_namespace
+  AND pltmp.lt_title = pg2.page_title
 WHERE
   EXISTS (
     SELECT

--- a/dbreps2/src/general/linkedredlinkedcats.rs
+++ b/dbreps2/src/general/linkedredlinkedcats.rs
@@ -45,9 +45,10 @@ SELECT
   cl_to,
   COUNT(*)
 FROM
+  /* FIXME when categorylinks gets normalized as well */
   categorylinks
-  JOIN pagelinks ON pl_title = cl_to
-  AND pl_namespace = 14
+  JOIN linktarget ON lt_title = cl_to AND lt_namespace = 14
+  JOIN pagelinks ON pl_target_id = lt_id
   JOIN page AS p1 ON pl_from = p1.page_id
   AND p1.page_namespace IN (0, 6, 10, 12, 14, 100)
   LEFT JOIN page AS p2 ON cl_to = p2.page_title

--- a/dbreps2/src/general/userlinksinarticles.rs
+++ b/dbreps2/src/general/userlinksinarticles.rs
@@ -45,9 +45,10 @@ SELECT
 FROM
   page
   JOIN pagelinks ON pl_from = page_id
+  JOIN linktarget ON pl_target_id = lt_id
 WHERE
   pl_from_namespace = 0
-  AND pl_namespace IN (2, 3)
+  AND lt_namespace IN (2, 3)
   AND NOT EXISTS (
     SELECT 1 FROM templatelinks
     JOIN linktarget ON tl_target_id = lt_id


### PR DESCRIPTION
According to https://phabricator.wikimedia.org/T343198 the pagelinks.pl_target_id column should have already been added to eqiad.