### PR TITLE
Run streak reports at the end

### DIFF
--- a/dbreps2/src/main.rs
+++ b/dbreps2/src/main.rs
@@ -58,11 +58,6 @@ async fn main() -> Result<()> {
     (general::UserLinksInArticles {})
         .really_run(&enwiki_runner)
         .await;
-    // taking longer than an hour
-    /*(general::UserArticleStreaks {})
-    .really_run(&enwiki_runner)
-    .await;*/
-    (general::UserStreaks {}).really_run(&enwiki_runner).await;
     (enwiki::BrokenWikiProjTemps {})
         .really_run(&enwiki_runner)
         .await;
@@ -132,6 +127,11 @@ async fn main() -> Result<()> {
     (enwiki::UserCats {}).really_run(&enwiki_runner).await;
     // FIXME: too slow?
     // (enwiki::WebhostPages {}).really_run(&enwiki_runner).await;
+    // these can be slow and are mostly just for fun, so run them last
+    (general::UserStreaks {}).really_run(&enwiki_runner).await;
+    (general::UserArticleStreaks {})
+        .really_run(&enwiki_runner)
+        .await;
 
     // Cleanup
     enwiki_runner.pool.disconnect().await?;


### PR DESCRIPTION
These can be slow and are mostly for fun and not maintenance
so run them last.
