### PR TITLE
Remove usage of async-trait macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,17 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,7 +469,6 @@ name = "dbreps2"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "dirs 5.0.1",
  "env_logger",

--- a/dbreps2/Cargo.toml
+++ b/dbreps2/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1.50"
 clap = { version = "4.3.0", features = ["derive"] }
 dirs = "5.0.1"
 env_logger = "0.10.0"

--- a/dbreps2/src/enwiki.rs
+++ b/dbreps2/src/enwiki.rs
@@ -73,5 +73,4 @@ pub use {
     untaggedunrefblps::UntaggedUnrefBLPs, unusednonfree::UnusedNonFree,
     unusedtemplates::UnusedTemplates,
     unusedtemplatesfiltered::UnusedTemplatesFiltered, usercats::UserCats,
-    webhostpages::WebhostPages,
 };

--- a/dbreps2/src/enwiki/boteditcount.rs
+++ b/dbreps2/src/enwiki/boteditcount.rs
@@ -107,7 +107,6 @@ pub struct Row {
 
 pub struct BotEditCount {}
 
-#[async_trait::async_trait]
 impl Report<Row> for BotEditCount {
     fn title(&self) -> &'static str {
         "<boteditcount>"

--- a/dbreps2/src/enwiki/brokenwikiprojtemps.rs
+++ b/dbreps2/src/enwiki/brokenwikiprojtemps.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct BrokenWikiProjTemps {}
 
-#[async_trait::async_trait]
 impl Report<Row> for BrokenWikiProjTemps {
     fn title(&self) -> &'static str {
         "Broken WikiProject templates"

--- a/dbreps2/src/enwiki/conflictedfiles.rs
+++ b/dbreps2/src/enwiki/conflictedfiles.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct ConflictedFiles {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ConflictedFiles {
     fn title(&self) -> &'static str {
         "Files with conflicting categorization"

--- a/dbreps2/src/enwiki/editcount.rs
+++ b/dbreps2/src/enwiki/editcount.rs
@@ -133,7 +133,6 @@ pub struct Row {
 
 pub struct EditCount {}
 
-#[async_trait::async_trait]
 impl Report<Row> for EditCount {
     fn title(&self) -> &'static str {
         "<placeholder>"

--- a/dbreps2/src/enwiki/emptycats.rs
+++ b/dbreps2/src/enwiki/emptycats.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct EmptyCats {}
 
-#[async_trait::async_trait]
 impl Report<Row> for EmptyCats {
     fn title(&self) -> &'static str {
         "Empty categories"

--- a/dbreps2/src/enwiki/featuredbysize.rs
+++ b/dbreps2/src/enwiki/featuredbysize.rs
@@ -32,7 +32,6 @@ pub struct FeaturedBySize {
     pub(crate) bot: Bot,
 }
 
-#[async_trait::async_trait]
 impl Report<Row> for FeaturedBySize {
     fn title(&self) -> &'static str {
         "Featured articles by size"

--- a/dbreps2/src/enwiki/linkedmiscapitalizations.rs
+++ b/dbreps2/src/enwiki/linkedmiscapitalizations.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct LinkedMiscapitalizations {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LinkedMiscapitalizations {
     fn title(&self) -> &'static str {
         "Linked miscapitalizations"

--- a/dbreps2/src/enwiki/linkedmisspellings.rs
+++ b/dbreps2/src/enwiki/linkedmisspellings.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct LinkedMisspellings {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LinkedMisspellings {
     fn title(&self) -> &'static str {
         "Linked misspellings"

--- a/dbreps2/src/enwiki/longstubs.rs
+++ b/dbreps2/src/enwiki/longstubs.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct LongStubs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LongStubs {
     fn title(&self) -> &'static str {
         "Long stubs"

--- a/dbreps2/src/enwiki/lotnonfree.rs
+++ b/dbreps2/src/enwiki/lotnonfree.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct LotNonFree {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LotNonFree {
     fn title(&self) -> &'static str {
         "Pages containing an unusually high number of non-free files"

--- a/dbreps2/src/enwiki/newprojects.rs
+++ b/dbreps2/src/enwiki/newprojects.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct NewProjects {}
 
-#[async_trait::async_trait]
 impl Report<Row> for NewProjects {
     fn title(&self) -> &'static str {
         "New WikiProjects"

--- a/dbreps2/src/enwiki/olddeletiondiscussions.rs
+++ b/dbreps2/src/enwiki/olddeletiondiscussions.rs
@@ -30,7 +30,6 @@ pub struct Row {
 
 pub struct OldDeletionDiscussions {}
 
-#[async_trait::async_trait]
 impl Report<Row> for OldDeletionDiscussions {
     fn title(&self) -> &'static str {
         "Old deletion discussions"

--- a/dbreps2/src/enwiki/orphanedafds.rs
+++ b/dbreps2/src/enwiki/orphanedafds.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct OrphanedAfds {}
 
-#[async_trait::async_trait]
 impl Report<Row> for OrphanedAfds {
     fn title(&self) -> &'static str {
         "Orphaned article deletion discussions"

--- a/dbreps2/src/enwiki/orphanedsubtalks.rs
+++ b/dbreps2/src/enwiki/orphanedsubtalks.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct OrphanedSubTalks {}
 
-#[async_trait::async_trait]
 impl Report<Row> for OrphanedSubTalks {
     fn title(&self) -> &'static str {
         "Orphaned talk subpages"

--- a/dbreps2/src/enwiki/overusednonfree.rs
+++ b/dbreps2/src/enwiki/overusednonfree.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct OverusedNonFree {}
 
-#[async_trait::async_trait]
 impl Report<Row> for OverusedNonFree {
     fn title(&self) -> &'static str {
         "Overused non-free files"

--- a/dbreps2/src/enwiki/polltemps.rs
+++ b/dbreps2/src/enwiki/polltemps.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct PollTemps {}
 
-#[async_trait::async_trait]
 impl Report<Row> for PollTemps {
     fn title(&self) -> &'static str {
         "Template categories containing articles"

--- a/dbreps2/src/enwiki/potenshbdps1.rs
+++ b/dbreps2/src/enwiki/potenshbdps1.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct Potenshbdps1 {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Potenshbdps1 {
     fn title(&self) -> &'static str {
         "Potential biographies of dead people (1)"

--- a/dbreps2/src/enwiki/potenshbdps3.rs
+++ b/dbreps2/src/enwiki/potenshbdps3.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct Potenshbdps3 {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Potenshbdps3 {
     fn title(&self) -> &'static str {
         "Potential biographies of dead people (3)"

--- a/dbreps2/src/enwiki/potenshblps1.rs
+++ b/dbreps2/src/enwiki/potenshblps1.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct Potenshblps1 {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Potenshblps1 {
     fn title(&self) -> &'static str {
         "Potential biographies of living people (1)"

--- a/dbreps2/src/enwiki/potenshblps2.rs
+++ b/dbreps2/src/enwiki/potenshblps2.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct Potenshblps2 {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Potenshblps2 {
     fn title(&self) -> &'static str {
         "Potential biographies of living people (2)"

--- a/dbreps2/src/enwiki/potenshblps3.rs
+++ b/dbreps2/src/enwiki/potenshblps3.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct Potenshblps3 {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Potenshblps3 {
     fn title(&self) -> &'static str {
         "Potential biographies of living people (3)"

--- a/dbreps2/src/enwiki/projectchanges.rs
+++ b/dbreps2/src/enwiki/projectchanges.rs
@@ -31,7 +31,6 @@ pub struct Row {
 
 pub struct ProjectChanges {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ProjectChanges {
     fn title(&self) -> &'static str {
         "WikiProjects by changes"

--- a/dbreps2/src/enwiki/shortestbios.rs
+++ b/dbreps2/src/enwiki/shortestbios.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct ShortestBios {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ShortestBios {
     fn title(&self) -> &'static str {
         "Shortest biographies of living people"

--- a/dbreps2/src/enwiki/stickyprodblps.rs
+++ b/dbreps2/src/enwiki/stickyprodblps.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct StickyProdBLPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for StickyProdBLPs {
     fn title(&self) -> &'static str {
         "Biographies of living people possibly eligible for deletion"

--- a/dbreps2/src/enwiki/templatedisambigs.rs
+++ b/dbreps2/src/enwiki/templatedisambigs.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct TemplateDisambigs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for TemplateDisambigs {
     fn title(&self) -> &'static str {
         "Templates containing links to disambiguation pages"

--- a/dbreps2/src/enwiki/templatesnonfree.rs
+++ b/dbreps2/src/enwiki/templatesnonfree.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct TemplatesNonFree {}
 
-#[async_trait::async_trait]
 impl Report<Row> for TemplatesNonFree {
     fn title(&self) -> &'static str {
         "Templates containing non-free files"

--- a/dbreps2/src/enwiki/unbelievablelifespans.rs
+++ b/dbreps2/src/enwiki/unbelievablelifespans.rs
@@ -31,7 +31,6 @@ pub struct Row {
 
 pub struct UnbelievableLifeSpans {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UnbelievableLifeSpans {
     fn title(&self) -> &'static str {
         "Unbelievable life spans"

--- a/dbreps2/src/enwiki/uncatunrefblps.rs
+++ b/dbreps2/src/enwiki/uncatunrefblps.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UncatUnrefBLPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UncatUnrefBLPs {
     fn title(&self) -> &'static str {
         "Uncategorized and unreferenced biographies of living people"

--- a/dbreps2/src/enwiki/unsourcedblps.rs
+++ b/dbreps2/src/enwiki/unsourcedblps.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UnsourcedBLPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UnsourcedBLPs {
     fn title(&self) -> &'static str {
         "Biographies of living people containing unsourced statements"

--- a/dbreps2/src/enwiki/untaggedblps.rs
+++ b/dbreps2/src/enwiki/untaggedblps.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UntaggedBLPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UntaggedBLPs {
     fn title(&self) -> &'static str {
         "Untagged biographies of living people"

--- a/dbreps2/src/enwiki/untaggedstubs.rs
+++ b/dbreps2/src/enwiki/untaggedstubs.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct UntaggedStubs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UntaggedStubs {
     fn title(&self) -> &'static str {
         "Untagged stubs"

--- a/dbreps2/src/enwiki/untaggedunrefblps.rs
+++ b/dbreps2/src/enwiki/untaggedunrefblps.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct UntaggedUnrefBLPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UntaggedUnrefBLPs {
     fn title(&self) -> &'static str {
         "Untagged and unreferenced biographies of living people"

--- a/dbreps2/src/enwiki/unusednonfree.rs
+++ b/dbreps2/src/enwiki/unusednonfree.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UnusedNonFree {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UnusedNonFree {
     fn title(&self) -> &'static str {
         "Unused non-free files"

--- a/dbreps2/src/enwiki/unusedtemplates.rs
+++ b/dbreps2/src/enwiki/unusedtemplates.rs
@@ -61,7 +61,6 @@ WHERE
     }
 }
 
-#[async_trait::async_trait]
 impl Report<Row> for UnusedTemplates {
     fn title(&self) -> &'static str {
         "Unused templates"

--- a/dbreps2/src/enwiki/unusedtemplatesfiltered.rs
+++ b/dbreps2/src/enwiki/unusedtemplatesfiltered.rs
@@ -80,7 +80,6 @@ WHERE
     }
 }
 
-#[async_trait::async_trait]
 impl Report<Row> for UnusedTemplatesFiltered {
     fn title(&self) -> &'static str {
         "Unused templates (filtered)"

--- a/dbreps2/src/enwiki/usercats.rs
+++ b/dbreps2/src/enwiki/usercats.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UserCats {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UserCats {
     fn title(&self) -> &'static str {
         "User categories"

--- a/dbreps2/src/enwiki/webhostpages.rs
+++ b/dbreps2/src/enwiki/webhostpages.rs
@@ -30,7 +30,6 @@ pub struct Row {
 
 pub struct WebhostPages {}
 
-#[async_trait::async_trait]
 impl Report<Row> for WebhostPages {
     fn title(&self) -> &'static str {
         "Potential U5s"

--- a/dbreps2/src/general.rs
+++ b/dbreps2/src/general.rs
@@ -37,9 +37,8 @@ pub use {
     dupefilenames::DupeFileNames, excessiveips::ExcessiveIps,
     excessiveusers::ExcessiveUsers, indeffullredirects::IndefFullRedirects,
     indefips::IndefIPs, linkedemailsinarticles::LinkedEmailsInArticles,
-    linkedredlinkedcats::LinkedRedlinkedCats, oldeditors::OldEditors,
-    ownerlessuserpages::Ownerlessuserpages, pollcats::Pollcats,
-    uncatcats::UncatCats, uncattemps::UncatTemps,
+    oldeditors::OldEditors, ownerlessuserpages::Ownerlessuserpages,
+    pollcats::Pollcats, uncatcats::UncatCats, uncattemps::UncatTemps,
     userarticlestreaks::UserArticleStreaks,
     userlinksinarticles::UserLinksInArticles, userstreaks::UserStreaks,
 };

--- a/dbreps2/src/general/articlesmostredirects.rs
+++ b/dbreps2/src/general/articlesmostredirects.rs
@@ -10,7 +10,6 @@ pub struct Row {
 
 pub struct ArticlesMostRedirects {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ArticlesMostRedirects {
     fn title(&self) -> &'static str {
         "Articles with the most redirects"

--- a/dbreps2/src/general/blankpages.rs
+++ b/dbreps2/src/general/blankpages.rs
@@ -25,7 +25,6 @@ pub struct Row {
 
 pub struct BlankPages;
 
-#[async_trait::async_trait]
 impl Report<Row> for BlankPages {
     fn title(&self) -> &'static str {
         "Blank single-author pages"

--- a/dbreps2/src/general/dupefilenames.rs
+++ b/dbreps2/src/general/dupefilenames.rs
@@ -13,7 +13,6 @@ pub struct Row {
     orig_names_str: String,
 }
 
-#[async_trait::async_trait]
 impl Report<Row> for DupeFileNames {
     fn title(&self) -> &'static str {
         "Largely duplicative file names"

--- a/dbreps2/src/general/excessiveips.rs
+++ b/dbreps2/src/general/excessiveips.rs
@@ -31,7 +31,6 @@ pub struct Row {
 
 pub struct ExcessiveIps {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ExcessiveIps {
     fn title(&self) -> &'static str {
         "Unusually long IP blocks"

--- a/dbreps2/src/general/excessiveusers.rs
+++ b/dbreps2/src/general/excessiveusers.rs
@@ -31,7 +31,6 @@ pub struct Row {
 
 pub struct ExcessiveUsers {}
 
-#[async_trait::async_trait]
 impl Report<Row> for ExcessiveUsers {
     fn title(&self) -> &'static str {
         "Unusually long user blocks"

--- a/dbreps2/src/general/indeffullredirects.rs
+++ b/dbreps2/src/general/indeffullredirects.rs
@@ -30,7 +30,6 @@ pub struct Row {
 
 pub struct IndefFullRedirects {}
 
-#[async_trait::async_trait]
 impl Report<Row> for IndefFullRedirects {
     fn title(&self) -> &'static str {
         "Indefinitely fully protected redirects"

--- a/dbreps2/src/general/indefips.rs
+++ b/dbreps2/src/general/indefips.rs
@@ -30,7 +30,6 @@ pub struct Row {
 
 pub struct IndefIPs {}
 
-#[async_trait::async_trait]
 impl Report<Row> for IndefIPs {
     fn title(&self) -> &'static str {
         "Indefinitely blocked IPs"

--- a/dbreps2/src/general/linkedemailsinarticles.rs
+++ b/dbreps2/src/general/linkedemailsinarticles.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct LinkedEmailsInArticles {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LinkedEmailsInArticles {
     fn title(&self) -> &'static str {
         "Articles containing linked e-mail addresses"

--- a/dbreps2/src/general/linkedredlinkedcats.rs
+++ b/dbreps2/src/general/linkedredlinkedcats.rs
@@ -28,7 +28,6 @@ pub struct Row {
 
 pub struct LinkedRedlinkedCats {}
 
-#[async_trait::async_trait]
 impl Report<Row> for LinkedRedlinkedCats {
     fn title(&self) -> &'static str {
         "Red-linked categories with incoming links"

--- a/dbreps2/src/general/oldeditors.rs
+++ b/dbreps2/src/general/oldeditors.rs
@@ -29,7 +29,6 @@ pub struct Row {
 
 pub struct OldEditors {}
 
-#[async_trait::async_trait]
 impl Report<Row> for OldEditors {
     fn title(&self) -> &'static str {
         "Active editors with the longest-established accounts"

--- a/dbreps2/src/general/ownerlessuserpages.rs
+++ b/dbreps2/src/general/ownerlessuserpages.rs
@@ -87,7 +87,6 @@ LIMIT
 
 pub struct Ownerlessuserpages {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Ownerlessuserpages {
     fn title(&self) -> &'static str {
         "Ownerless pages in the user space"

--- a/dbreps2/src/general/pollcats.rs
+++ b/dbreps2/src/general/pollcats.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct Pollcats {}
 
-#[async_trait::async_trait]
 impl Report<Row> for Pollcats {
     fn title(&self) -> &'static str {
         "Polluted categories"

--- a/dbreps2/src/general/uncatcats.rs
+++ b/dbreps2/src/general/uncatcats.rs
@@ -31,7 +31,6 @@ pub struct Row {
 
 pub struct UncatCats {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UncatCats {
     fn title(&self) -> &'static str {
         "Uncategorized categories"

--- a/dbreps2/src/general/uncattemps.rs
+++ b/dbreps2/src/general/uncattemps.rs
@@ -9,7 +9,6 @@ pub struct Row {
 
 pub struct UncatTemps {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UncatTemps {
     fn title(&self) -> &'static str {
         "Uncategorized templates"

--- a/dbreps2/src/general/userarticlestreaks.rs
+++ b/dbreps2/src/general/userarticlestreaks.rs
@@ -38,7 +38,6 @@ pub struct Row {
 
 pub struct UserArticleStreaks {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UserArticleStreaks {
     fn title(&self) -> &'static str {
         "Longest active user article editing streaks"

--- a/dbreps2/src/general/userlinksinarticles.rs
+++ b/dbreps2/src/general/userlinksinarticles.rs
@@ -27,7 +27,6 @@ pub struct Row {
 
 pub struct UserLinksInArticles {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UserLinksInArticles {
     fn title(&self) -> &'static str {
         "Articles containing links to the user space"

--- a/dbreps2/src/general/userstreaks.rs
+++ b/dbreps2/src/general/userstreaks.rs
@@ -38,7 +38,6 @@ pub struct Row {
 
 pub struct UserStreaks {}
 
-#[async_trait::async_trait]
 impl Report<Row> for UserStreaks {
     fn title(&self) -> &'static str {
         "Longest active user editing streaks"

--- a/dbreps2/src/lib.rs
+++ b/dbreps2/src/lib.rs
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#![allow(async_fn_in_trait)]
 use anyhow::Result;
 use log::{error, info};
 use mwbot::{Bot, Page, SaveOptions};
@@ -114,7 +115,6 @@ impl Display for Frequency {
     }
 }
 
-#[async_trait::async_trait]
 pub trait Report<T: Send + Sync> {
     // TODO: Make this per-wiki/language
     fn title(&self) -> &'static str;


### PR DESCRIPTION
Now supported by default in Rust 1.75, mostly.