### PR TITLE
Ignore more "Redirects to Wiki..." categories in Untagged stubs

### DIFF
--- a/dbreps2/src/enwiki/untaggedstubs.rs
+++ b/dbreps2/src/enwiki/untaggedstubs.rs
@@ -48,6 +48,7 @@ FROM
   LEFT JOIN categorylinks ON cl_from = page_id
   AND (
     cl_to LIKE '%_stubs'
+    OR cl_to LIKE 'Redirects_to_Wiki%'
     OR cl_to IN (
       'All_disambiguation_pages',
       'All_set_index_articles',


### PR DESCRIPTION
Per <https://en.wikipedia.org/wiki/Wikipedia_talk:Database_reports#c-CFA-20240713193000-Wikipedia:Database_reports/Untagged_stubs_false_positives>.