### PR TITLE
Don't update reports on pages containing {{database report}}

### DIFF
--- a/dbreps2/src/lib.rs
+++ b/dbreps2/src/lib.rs
@@ -192,6 +192,9 @@ pub trait Report<T: Send + Sync> {
                 return Ok(true);
             }
         }
+        if contains_nobot(old_text) {
+            return Ok(false);
+        }
         let re = Regex::new("<onlyinclude>(.*?)</onlyinclude>").unwrap();
         let ts = match re.captures(old_text) {
             Some(cap) => cap[1].to_string(),
@@ -450,6 +453,10 @@ pub fn y_m_d(input: &str) -> String {
         .unwrap_or_else(|_| input.to_string())
 }
 
+pub fn contains_nobot(text: &str) -> bool {
+    Regex::new("\\{\\{nobots}}").unwrap().is_match(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,6 +520,18 @@ mod tests {
         assert_eq!(
             &Frequency::DailyAt(3).to_string(),
             "This report is updated every day at 3:00 UTC."
+        );
+    }
+
+    #[test]
+    fn test_contains_nobot() {
+        assert_eq!(
+            contains_nobot("{{nobots}}. Some text here."),
+            true
+        );
+        assert_eq!(
+            contains_nobot("Some text here"),
+            false
         );
     }
 }

--- a/dbreps2/src/lib.rs
+++ b/dbreps2/src/lib.rs
@@ -192,6 +192,9 @@ pub trait Report<T: Send + Sync> {
                 return Ok(true);
             }
         }
+
+        // Pages with {{database report}} are maintained by SDZeroBot and contain the SQL queries
+        // directly. Skip updating the report if it has been migrated to use that template.
         if contains_database_report_template(old_text) {
             return Ok(false);
         }

--- a/dbreps2/src/lib.rs
+++ b/dbreps2/src/lib.rs
@@ -192,7 +192,7 @@ pub trait Report<T: Send + Sync> {
                 return Ok(true);
             }
         }
-        if contains_nobot(old_text) {
+        if contains_database_report_template(old_text) {
             return Ok(false);
         }
         let re = Regex::new("<onlyinclude>(.*?)</onlyinclude>").unwrap();
@@ -453,8 +453,10 @@ pub fn y_m_d(input: &str) -> String {
         .unwrap_or_else(|_| input.to_string())
 }
 
-pub fn contains_nobot(text: &str) -> bool {
-    Regex::new("\\{\\{nobots}}").unwrap().is_match(text)
+pub fn contains_database_report_template(text: &str) -> bool {
+    Regex::new("\\{\\{[Dd]atabase report\\s*\\|")
+        .unwrap()
+        .is_match(text)
 }
 
 #[cfg(test)]
@@ -524,14 +526,18 @@ mod tests {
     }
 
     #[test]
-    fn test_contains_nobot() {
+    fn test_contains_database_report_template() {
+        assert_eq!(contains_database_report_template(
+            "Some text here. {{database report|sql=SELECT * FROM page LIMIT 10}}"), true);
         assert_eq!(
-            contains_nobot("{{nobots}}. Some text here."),
+            contains_database_report_template(
+                "Some text here. \
+            {{database report\
+            |sql=SELECT * FROM page LIMIT 10\
+            }}"
+            ),
             true
         );
-        assert_eq!(
-            contains_nobot("Some text here"),
-            false
-        );
+        assert_eq!(contains_database_report_template("Some text here"), false);
     }
 }


### PR DESCRIPTION
Minimal support for skipping pages containing {{[nobots](https://en.wikipedia.org/w/index.php?title=Template:Nobots)}}. Only pages with the exact string are skipped for now.

This enables community members to replace broken reports with ones based on {{[Database report](https://en.wikipedia.org/wiki/Template:Database_report)}}, without having to worry about the bot eventually overwriting the migrated (and possibly improved) queries. {{Database report}} makes the SQL community-controlled, making it easy to fix and enhance. The bot which updates the template-based reports doesn't honor {{nobots}}.